### PR TITLE
Only run the build step if a build script is present

### DIFF
--- a/npm-ci/action.yml
+++ b/npm-ci/action.yml
@@ -14,7 +14,7 @@ runs:
     shell: bash
 
   - name: Build package
-    run: npm run build
+    run: npm run build --if-present
     shell: bash
 
   - name: Fetch from main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
AlexGBot is not going through a build process as of now, so without this, CI will always fail there.